### PR TITLE
[PR] Auth Sign-out Sign-in Loop

### DIFF
--- a/app/src/main/java/com/nebo/timing/MainActivity.java
+++ b/app/src/main/java/com/nebo/timing/MainActivity.java
@@ -123,11 +123,10 @@ public class MainActivity extends AppCompatActivity {
                         .signOut(MainActivity.this)
                         .addOnCompleteListener(new OnCompleteListener<Void>() {
                             public void onComplete(@NonNull Task<Void> task) {
-                                // user is now signed out
-                                // startActivity(new Intent(MainActivity.this, SignInActivity.class));
                                 finish();
                             }
                         });
+
 
             }
         });
@@ -151,5 +150,10 @@ public class MainActivity extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
         Log.d(TAG, "onPause");
+
+        if (mAuthStateListener != null) {
+            mFirebaseAuth.removeAuthStateListener(mAuthStateListener);
+            mAuthStateListener = null;
+        }
     }
 }


### PR DESCRIPTION
BUG Description

Previously sign-out operation from the user would cause the sign-in
logic to start and then close the application.  Instead now, since
`onPause` is called prior to the `authStateChangedListener` went ahead
and removed the `authStateChangeListener` from the `FirebaseAuth`
reference.

Related Issues
- #10
- #12