### PR TITLE
[FTR] onTick Reduction

### DIFF
--- a/app/src/main/java/com/nebo/timing/data/CountUpTimer.java
+++ b/app/src/main/java/com/nebo/timing/data/CountUpTimer.java
@@ -75,11 +75,13 @@ public class CountUpTimer  {
     }
 
     private void onTick(long millisUntilFinished) {
-        // 1. need to save state to support pause & resume functionality.
-        mTimeRemaining = millisUntilFinished;
+        if (mCountDownInterval != mMillisInFuture) {
+            // 1. need to save state to support pause & resume functionality.
+            mTimeRemaining = millisUntilFinished;
 
-        // 2. Operate on the caller defined onTick method.
-        mCallback.onTick(millisUntilFinished);
+            // 2. Operate on the caller defined onTick method.
+            mCallback.onTick(millisUntilFinished);
+        }
     }
 
     private void onFinish() {

--- a/app/src/main/java/com/nebo/timing/ui/StopWatchFragment.java
+++ b/app/src/main/java/com/nebo/timing/ui/StopWatchFragment.java
@@ -82,7 +82,9 @@ public class StopWatchFragment extends Fragment implements CountUpTimer.OnTimerE
     }
 
     @Override
-    public void onTick(long millisUntilFinished) {}
+    public void onTick(long millisUntilFinished) {
+        Log.d(TAG, "onTick");
+    }
 
     @Override
     public void onFinish() {


### PR DESCRIPTION
Feature Description

When the interval and future value are the same, the count up timer class will
not queue the `onTick` method to the controlling class.

Related Issues
- #21
- #22