### PR TITLE
[PR] Pause & Reset State

### DIFF
--- a/app/src/main/java/com/nebo/timing/data/StopWatch.java
+++ b/app/src/main/java/com/nebo/timing/data/StopWatch.java
@@ -123,6 +123,7 @@ public class StopWatch {
                 prevTime = -1;
                 break;
             case PAUSED:
+                prevTime = System.currentTimeMillis();
                 break;
             case STOPPED:
                 mMilliSeconds = 0L;

--- a/app/src/main/java/com/nebo/timing/ui/StopWatchFragment.java
+++ b/app/src/main/java/com/nebo/timing/ui/StopWatchFragment.java
@@ -187,6 +187,11 @@ public class StopWatchFragment extends Fragment {
         mBinding.ibReplay.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                mStopWatch.stop();
+                mLapTimes.clear();
+                ((LapAdapter)mBinding.rvLaps.getAdapter()).clearLapTimes();
+                ((LapAdapter) mBinding.rvLaps.getAdapter()).addNewLapTime(getString(R.string.default_time));
+                mLapTimes.add(0, 0L);
                 mStopWatch.play();
             }
         });


### PR DESCRIPTION
Feature Description

Previously a pause to play transistion would keep the last time as the time
that was last seen from the tick event resolution.  This meant once play was
pressed the displayed time would include the time that elapsed within the
pause state.

Now for the transition from pause to play state in the stop watch, the
prevTime for the difference calculation is set prior to finalizing the state
transition.

Additionally, the reset had been neglected and has now been updated to perform
the same functionality as the stop but also followed by the play.

Related Issues
- #29