### PR TITLE
[PR] Skipping Time & LifeCycle Adjustments

### DIFF
--- a/app/src/main/java/com/nebo/timing/StopWatchActivity.java
+++ b/app/src/main/java/com/nebo/timing/StopWatchActivity.java
@@ -75,8 +75,42 @@ public class StopWatchActivity extends AppCompatActivity implements
     }
 
     @Override
+    protected void onPause() {
+        super.onPause();
+        if (mStopWatch != null) {
+            mStopWatch.unRegisterCallback();
+        }
+        Log.d("StopWatchActivity", "onPause");
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (mStopWatch != null) {
+            mStopWatch.registerCallback(this);
+        }
+        Log.d("StopWatchActivity", "onResume");
+
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        Log.d("StopWatchActivity", "onStop");
+
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        Log.d("StopWatchActivity", "onDestroy");
+
+    }
+
+    @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+        Log.d("StopWatchActivity", "onSaveInstanceState");
         long [] times = new long [mLaps.size()];
 
         int index = 0;
@@ -90,13 +124,15 @@ public class StopWatchActivity extends AppCompatActivity implements
                     getString(R.string.key_stopwatch_state),
                     mStopWatch.getState().getStateValue());
             outState.putLongArray(getString(R.string.key_lap_times), times);
-            mStopWatch.stop();
         }
     }
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        Log.d("StopWatchActivity", "onCreate");
+
         mBinding = DataBindingUtil.setContentView(this, R.layout.activity_stopwatch);
         long baseTime = 0L;
         List<String> timeStrings = new LinkedList<String>();
@@ -110,10 +146,17 @@ public class StopWatchActivity extends AppCompatActivity implements
             long [] times = savedInstanceState.getLongArray(getString(R.string.key_lap_times));
 
             if (times != null && times.length > 0) {
+                baseTime = times[0];
                 for (long time : times) {
-                    baseTime += time;
                     mLaps.add(time);
                     timeStrings.add(StopWatch.buildTimeStamp(time));
+                    // Log.d("onCreate", "time found is " + Long.toString(time));
+                }
+
+                // need to account for the first lap time.
+                if (mLaps.size() > 1) {
+                    timeStrings.set(0,
+                            StopWatch.buildTimeStamp(baseTime - mLaps.get(1)));
                 }
             }
 
@@ -181,6 +224,8 @@ public class StopWatchActivity extends AppCompatActivity implements
 
     @Override
     public void tickEvent(long milliSecondsElapsed) {
+        Log.d("StopWatchActivity", "tickEvent");
+
         Long lastLapTime = 0L;
         String totalTimeDisplay = null, lapTimeDisplay = null;
 

--- a/app/src/main/java/com/nebo/timing/data/StopWatch.java
+++ b/app/src/main/java/com/nebo/timing/data/StopWatch.java
@@ -42,7 +42,9 @@ public class StopWatch {
             }
 
             prevTime = time;
-            mCallback.tickEvent(mMilliSeconds);
+            if (mCallback != null) {
+                mCallback.tickEvent(mMilliSeconds);
+            }
         }
 
         @Override
@@ -90,6 +92,27 @@ public class StopWatch {
          public int getStateValue() {
             return number;
          }
+    }
+
+    /**
+     * @func unRegisterCallback
+     * @brief when the controlling element exists from its life-cycle want to make sure that before
+     *        it does that the callback is set to null such that a delivery is not attempted on a
+     *        null process definition.
+     */
+    public void unRegisterCallback() {
+        mCallback = null;
+    }
+
+    /**
+     * @funct registerCallback
+     * @brief allows for the owner to re-establish the callback that is responsible for handling
+     *        tick events.
+     * @param callback - interface defined class that is responsible for defining where onTick
+     *                   callbacks are sent.
+     */
+    public void registerCallback(StopWatchTickEvents callback) {
+        mCallback = callback;
     }
 
     /**


### PR DESCRIPTION
Feature Description

In the event that life-cycle event occur, wanted to address that there is a chance
that the fragments are not setup for when the delievery of a `onTick` event from
the `StopWatch` activity.  To reduce this chance the `onPause` lifecycle event
will now cause an unregister of the callback of the `StopWatchActivity` with its
`StopWatch` object.  When the activity returns with an onCreate or resume a
register event of the callback occurs.

Additionally fixed the jumping of time due to the first value in the laps is the
current elapsed time as well.  Therefore do not need to sum all the lap times to
obtain the elapsed time.  Only need to account for the first lap time in the event
that there is more than one lap time.  This is just the string representation that
would likely get fixed on the first `onTick` but the `StopWatchActivity` state
could be stopped with invalid represnetation.

Related Issues
- #31
- #32
- #33
- #34