### PR TITLE
[PR] Selectable Activities

### DIFF
--- a/app/src/main/java/com/nebo/timing/StopWatchActivity.java
+++ b/app/src/main/java/com/nebo/timing/StopWatchActivity.java
@@ -12,6 +12,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 
 import com.nebo.timing.data.StopWatch;
+import com.nebo.timing.data.TimedActivity;
 import com.nebo.timing.databinding.ActivityStopwatchBinding;
 import com.nebo.timing.ui.ElapsedTimeFragment;
 import com.nebo.timing.ui.LapTimesFragment;
@@ -29,6 +30,7 @@ public class StopWatchActivity extends AppCompatActivity implements
     private ActivityStopwatchBinding mBinding = null;
     private StopWatch mStopWatch = null;
     private List<Long> mLaps = null;
+    private List<TimedActivity> mTimedActivities = new ArrayList<>();
 
     private void createLap() {
         LapTimesFragment lapTimesFragment = (LapTimesFragment) getSupportFragmentManager()
@@ -94,6 +96,9 @@ public class StopWatchActivity extends AppCompatActivity implements
 
         bundle.putLong(getString(R.string.key_total_time), totalTime);
         bundle.putLongArray(getString(R.string.key_lap_times), lapsToSave);
+        bundle.putParcelableArrayList(
+                getString(R.string.key_timed_activities),
+                (ArrayList<TimedActivity>) mTimedActivities);
 
         Intent intent = new Intent();
         intent.putExtras(bundle);
@@ -150,6 +155,10 @@ public class StopWatchActivity extends AppCompatActivity implements
                     mStopWatch.getState().getStateValue());
             outState.putLongArray(getString(R.string.key_lap_times), times);
         }
+
+        outState.putParcelableArrayList(
+                getString(R.string.key_timed_activities),
+                (ArrayList<TimedActivity>) mTimedActivities);
     }
 
     @Override
@@ -185,9 +194,21 @@ public class StopWatchActivity extends AppCompatActivity implements
 
             stopWatchState = savedInstanceState.getInt(getString(R.string.key_stopwatch_state),
                     StopWatch.sSTOP_STATE_VALUE);
+
+            mTimedActivities = savedInstanceState.
+                    getParcelableArrayList(getString(R.string.key_timed_activities));
         }
         else {
             // Check intent data
+            Bundle bundle = getIntent().getExtras();
+            if (bundle != null) {
+                mTimedActivities = bundle.
+                        getParcelableArrayList(getString(R.string.key_timed_activities));
+            }
+        }
+
+        if (mTimedActivities == null) {
+            mTimedActivities = new ArrayList<>();
         }
 
         // Create the stopwatch object.

--- a/app/src/main/java/com/nebo/timing/TimedActivityAdapter.java
+++ b/app/src/main/java/com/nebo/timing/TimedActivityAdapter.java
@@ -46,6 +46,11 @@ public class TimedActivityAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
     }
 
+    public void clearActivities() {
+        mTimedActivities.clear();
+        notifyDataSetChanged();
+    }
+
     @NonNull
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {


### PR DESCRIPTION
Feature Description

Taking advantage of the Callback state stack.  The current callback state stack
will actually cache the activities prior to switching from the stopwatch activity
and the select activity but after the `onPause` is called.  Odd behavior and might
be limited to the device I am using.  So to take advantage of this to have a valid
selection list just provided the list of all the activities.

If it ends up being device specific, can pass in the maps as well, as just lists
and then rebuild afterward.  Would expect a null pointer exception however since
the state of teh firebase db connect to then be invalid.

Related Issues
- #62
- #64
- #65